### PR TITLE
refactor(env): mark `getEnvironment()` as deprecated

### DIFF
--- a/applications/packages/core/core.env/package.json
+++ b/applications/packages/core/core.env/package.json
@@ -3,7 +3,7 @@
     "name": "@wraithlight/core.env",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "license": "LGPL-3.0-only",
     "scripts": {
         "lerna": "lerna",

--- a/applications/packages/core/core.env/src/env/env.ts
+++ b/applications/packages/core/core.env/src/env/env.ts
@@ -2,6 +2,13 @@ import { EnvironmentType } from "@wraithlight/core.common-constant";
 
 import { WL_TYPE_PROP_NAME } from "./env.const";
 
+/**
+ * @deprecated Use `getEnvironmentType()` instead.
+ */
 export function getEnvironment(): EnvironmentType {
+    return process.env[WL_TYPE_PROP_NAME] as EnvironmentType || EnvironmentType.Local;
+}
+
+export function getEnvironmentType(): EnvironmentType {
     return process.env[WL_TYPE_PROP_NAME] as EnvironmentType || EnvironmentType.Local;
 }


### PR DESCRIPTION
Ref: #151